### PR TITLE
CV2-6381: Update base image and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN mkdir -p /usr/local/var/run/watchman && touch /usr/local/var/run/watchman/.n
 RUN true \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        ruby2.5 \
-        ruby2.5-dev \
+        ruby2.7 \
+        ruby2.7-dev \
         build-essential \
         graphicsmagick \
-        python-pip \
-        python-setuptools \
-        python-wheel \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
         tini \
         zip \
         libidn11-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-buster AS base
+FROM node:14.21.3-bullseye AS base
 MAINTAINER Meedan <sysops@meedan.com>
 
 # TODO develop our own `watchman` image, so we can version it


### PR DESCRIPTION
## Description

Updated from node:12.16.1-buster to node:14.21.3-bullseye
Switched from ruby2.5 to ruby2.7 to ruby2.5-dev to ruby2.7-dev
Replaced deprecated python-pip, python-setuptools, and python-wheel with their Python 3 equivalents: python3-pip, python3-setuptools, and python3-wheel

References: CV2-6381